### PR TITLE
Add to list of dependencies in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ WIP COSMIC media player
 
 For debian-based systems:
 ```
-sudo apt-get install clang libasound2-dev libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev pkg-config
+sudo apt-get install clang just libasound2-dev libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev pkg-config
 ```

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ WIP COSMIC media player
 
 For debian-based systems:
 ```
-sudo apt-get install clang libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev pkg-config
+sudo apt-get install clang libasound2-dev libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavutil-dev pkg-config
 ```


### PR DESCRIPTION
`libasound2-dev` is a requirement of the `alsa-sys` crate. `alsa-sys` is a dependency of the `alsa` crate, which is used in turn by the `cpal` crate. 

This PR adds it to the code block in the readme, and places it in correct alphabetical order with the other listed packages.

Edit:
Added `just` as well. Also in the correct place alphabetically.