### PR TITLE
i18n(it): Improving Italian translation

### DIFF
--- a/i18n/it/cosmic_player.ftl
+++ b/i18n/it/cosmic_player.ftl
@@ -1,11 +1,11 @@
 # Context Pages
 
 ## Settings
-settings = Opzioni
+settings = Impostazioni
 
 ### Appearance
 appearance = Aspetto
 theme = Tema
-match-desktop = Automatico
-dark = Oscuro
+match-desktop = Abbina alla scrivania
+dark = Scuro
 light = Chiaro


### PR DESCRIPTION
Fixed translation for consistency with [cosmic-settings](https://github.com/pop-os/cosmic-settings/blob/master/i18n/it/cosmic_settings.ftl) and another minor detail:

`Dark` can be translated as both `oscuro` and `scuro`, but `oscuro` in modern Italian adds a slight touch of negativity in the meaning, since it's generally used for evil or unknown things (EG dark knight = cavaliere oscuro, dark lord = signore oscuro, dark age = età oscura). I think `scuro` is a more appropriate translation since it's more commonly only related to color (EG dark color = colore scuro, dark skin tone = pelle scura).