### PR TITLE
Support loading multiple file URLs (CLI/file managers)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "libcosmic",
  "log",
  "mpris-server",
+ "pico-args",
  "rust-embed",
  "serde",
  "smol_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1", features = ["serde_derive"] }
 tempfile = "3"
 tokio = "1"
 url = "2"
+pico-args = "0.5"
 # Internationalization
 icu_collator = "1.5"
 icu_provider = { version = "1.5", features = ["sync"] }

--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -8,8 +8,10 @@ use url::Url;
 
 #[derive(Debug, Default)]
 pub struct Arguments {
-    /// URLs to play with associated metadata
-    pub urls: Vec<Url>,
+    /// Files or directory URLs to play
+    pub urls: Option<Vec<Url>>,
+    /// Single URL only
+    pub url_opt: Option<Url>,
 }
 
 impl Arguments {
@@ -31,7 +33,17 @@ impl Arguments {
             warn!("Unused argument: {arg:?}");
         }
 
-        Ok(Arguments { urls })
+        if urls.len() > 1 {
+            Ok(Arguments {
+                urls: Some(urls),
+                ..Default::default()
+            })
+        } else {
+            Ok(Arguments {
+                url_opt: urls.into_iter().next(),
+                ..Default::default()
+            })
+        }
     }
 }
 

--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -1,0 +1,71 @@
+// Copyright 2024 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::{fs, io};
+
+use log::warn;
+use url::Url;
+
+#[derive(Debug, Default)]
+pub struct Arguments {
+    /// URLs to play with associated metadata
+    pub urls: Vec<Url>,
+}
+
+impl Arguments {
+    pub fn from_args() -> Result<Self, pico_args::Error> {
+        let mut parser = pico_args::Arguments::from_env();
+
+        // Freestanding arguments are treated as URLs
+        let urls: Vec<Url> = std::iter::from_fn(|| {
+            parser
+                .opt_free_from_fn(|arg| Source::try_from(arg))
+                .ok()
+                .flatten()
+        })
+        .map(|source| source.0)
+        .collect();
+
+        let remainder = parser.finish();
+        for arg in remainder {
+            warn!("Unused argument: {arg:?}");
+        }
+
+        Ok(Arguments { urls })
+    }
+}
+
+// #[derive(Debug)]
+// pub enum Source {
+//     File(Url),
+//     Directory(Url),
+//     // TODO: GStreamer handles streaming out of the box
+//     Other(Url),
+// }
+
+struct Source(Url);
+
+impl TryFrom<&str> for Source {
+    type Error = io::Error;
+
+    fn try_from(arg: &str) -> Result<Self, Self::Error> {
+        match url::Url::parse(arg) {
+            Ok(url) => Ok(Source(url)),
+            Err(_) => match fs::canonicalize(arg) {
+                Ok(path) => {
+                    match Url::from_file_path(&path).or_else(|_| Url::from_directory_path(&path)) {
+                        Ok(url) => Ok(Source(url)),
+                        Err(()) => {
+                            warn!("failed to parse path {:?}", path);
+                            Err(io::Error::other("Invalid URL and path"))
+                        }
+                    }
+                }
+                Err(err) => {
+                    warn!("failed to parse argument {:?}: {}", arg, err);
+                    Err(err)
+                }
+            },
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ use crate::{
     project::ProjectNode,
 };
 
+mod argparse;
 mod config;
 mod key_bind;
 mod localize;
@@ -110,25 +111,8 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     settings = settings.theme(config.app_theme.theme());
     settings = settings.size_limits(Limits::NONE.min_width(360.0).min_height(180.0));
 
-    let url_opt = match std::env::args().nth(1) {
-        Some(arg) => match url::Url::parse(&arg) {
-            Ok(url) => Some(url),
-            Err(_) => match fs::canonicalize(&arg) {
-                Ok(path) => match url::Url::from_file_path(&path).or_else(|_| url::Url::from_directory_path(&path)) {
-                    Ok(url) => Some(url),
-                    Err(()) => {
-                        log::warn!("failed to parse path {:?}", path);
-                        None
-                    }
-                },
-                Err(err) => {
-                    log::warn!("failed to parse argument {:?}: {}", arg, err);
-                    None
-                }
-            },
-        },
-        None => None,
-    };
+    let args = argparse::Arguments::from_args().unwrap_or_default();
+    let url_opt = args.urls.into_iter().next();
 
     let flags = Flags {
         config_handler,


### PR DESCRIPTION
Closes: #44 

This patch adds support for starting COSMIC Player with multiple, mixed URLs. As in #75, this is primarily useful for file managers which may start the program with multiple files and folders.

I added [pico-args](https://github.com/RazrFalcon/pico-args) as a dependency to aid argument parsing. `pico-args` doesn't have any dependencies and only adds [1KB](https://github.com/rosetta-rs/argparse-rosetta-rs) of binary bloat as opposed to `clap` which adds almost a megabyte of bloat. I used a dependency instead of simply looping through the arguments because I assume that command line args will be added in the future, so I might as well implement this the right way instead of adding maintenance burden.

I did not update the `Open File` button to take advantage of the new functionality. However, it should be a lot easier now to support that in a future patch.