### PR TITLE
Add daemon mode support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,6 +1072,7 @@ version = "0.1.0"
 dependencies = [
  "dirs",
  "env_logger",
+ "fork",
  "gstreamer-tag",
  "i18n-embed",
  "i18n-embed-fl",
@@ -1764,6 +1765,15 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "fork"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05dc8b302e04a1c27f4fe694439ef0f29779ca4edc205b7b58f00db04e29656d"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "form_urlencoded"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ optional = true
 version = "0.2.1"
 features = ["serde"]
 
+[target.'cfg(unix)'.dependencies]
+fork = "0.2"
+
 [features]
 default = ["mpris-server", "xdg-portal", "wgpu"]
 xdg-portal = ["libcosmic/xdg-portal"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,17 @@ fn language_name(code: &str) -> Option<String> {
 
 /// Runs application with these settings
 #[rustfmt::skip]
-pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(all(unix, not(target_os = "redox")))]
+    match fork::daemon(true, true) {
+        Ok(fork::Fork::Child) => (),
+        Ok(fork::Fork::Parent(_child_pid)) => process::exit(0),
+        Err(err) => {
+            eprintln!("failed to daemonize: {:?}", err);
+            process::exit(1);
+        }
+    }
+	
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
 
     localize::localize();


### PR DESCRIPTION
Enable daemon mode on Unix.

Improves behavior when launching cosmic-player from a terminal, preventing it from blocking the session.

Makes it easier to run the application as a background service.