### PR TITLE
fix(args): Eliminate the binary from arguments

### DIFF
--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -14,6 +14,7 @@ pub fn parse() -> Arguments {
     let mut urls = Vec::new();
 
     // Parse the arguments
+    raw_args.next(&mut cursor);
     while let Some(arg) = raw_args.next(&mut cursor) {
         if let Some(mut shorts) = arg.to_short() {
             while let Some(short) = shorts.next_flag() {


### PR DESCRIPTION
For an executable the first argument is always the binary itself. Because of this we have to skip it.

If we don't skip it, then it will be treated as another URL, therefore `cosmic-player` will end up opening two URLs, one for the binary and one for the actual file we want to play.

When opening multiple files `cosmic-player` will show the side panel / playlist with the list of files.

The regression this commit fixed was introduced by `01be9152`.

Closes #96.