### PR TITLE
feat(controls): Hide header bar if no mouse movement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -596,9 +596,11 @@ impl App {
                 .as_ref()
                 .map_or(false, |video| video.has_video())
         {
+            self.core.window.show_headerbar = true && !self.fullscreen;
             self.controls = true;
             self.controls_time = Instant::now();
         } else if self.controls && self.controls_time.elapsed() > CONTROLS_TIMEOUT {
+            self.core.window.show_headerbar = false;
             self.controls = false;
         }
         self.update_mpris_state();


### PR DESCRIPTION
We hide the title bar similarly on how we hide the controls bar.

The difference between the header bar and the controls bar is that in `Fullscreen` mode we don't display the header bar even if we have mouse movement.

If a menu or sub-menu is open, but then the user makes no mouse movement, then the menus will be hidden when the header bar is hidden.

I'm not sure how to handle the side panel, the `nav_bar`, what I call "the playlist". I decided to not handle it's hiding based on mouse movement because it is still displayed when we put the window in `Fullscreen` mode.

Closes #37