### PR TITLE
Handle videos with orientation metadata (like vertical phone recordings) with the videoflip filter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -350,7 +350,7 @@ impl App {
             gst::init().unwrap();
 
             let pipeline = format!(
-                "playbin uri=\"{}\" video-sink=\"videoscale ! videoconvert ! appsink name=iced_video drop=true caps=video/x-raw,format=NV12,pixel-aspect-ratio=1/1\"",
+                "playbin uri=\"{}\" video-sink=\"videoscale ! videoconvert ! videoflip method=automatic ! appsink name=iced_video drop=true caps=video/x-raw,format=NV12,pixel-aspect-ratio=1/1\"",
                 url.as_str()
             );
             let pipeline = gst::parse::launch(pipeline.as_ref())


### PR DESCRIPTION
This PR adds a [videoflip](https://gstreamer.freedesktop.org/documentation/videofilter/videoflip.html?gi-language=c) element to the pipeline with `method=automatic` to take advantage of GStreamer's existing orientation metadata handling.

This is my first exposure to gstreamer, so I'm not certain this is the ideal and complete solution, but it resolves #122 and the sample video is shown in the correct orientation.
