### PR TITLE
Fix mouse cursor showing in Fullscreen video

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1181,6 +1181,7 @@ impl Application for App {
 
                 self.fullscreen = !self.fullscreen;
                 self.core.window.show_headerbar = !self.fullscreen;
+                self.controls = !self.fullscreen;
                 return window::change_mode(
                     window::Id::MAIN,
                     if self.fullscreen {


### PR DESCRIPTION
In response to issue https://github.com/pop-os/cosmic-player/issues/159

Hi, this is my first contribution here. I just discovered the Cosmic project and I am so enthusiast about it! To me, this issue seemed to be a good first one.
When we press the F key, `Message::Fullscreen` is triggered. Compared to the mechanism to hide control after timeout (`fn update_controls()`),  a line for `self.controls` was missing.