### PR TITLE
Clean up dependencies, lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,6 @@ name = "cosmic-player"
 version = "0.1.0"
 dependencies = [
  "clap_lex",
- "dirs",
  "env_logger",
  "fork",
  "gstreamer-tag",
@@ -1093,13 +1092,11 @@ dependencies = [
  "icu_collator",
  "icu_provider",
  "image",
- "lazy_static",
  "libcosmic",
  "log",
  "mpris-server",
  "rust-embed",
  "serde",
- "smol_str",
  "tempfile",
  "tokio",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,8 @@ edition = "2021"
 vergen = { version = "8", features = ["git", "gitcl"] }
 
 [dependencies]
-dirs = "5"
 gstreamer-tag = "0.23"
 image = "0.24.9"
-lazy_static = "1"
 serde = { version = "1", features = ["serde_derive"] }
 tempfile = "3"
 tokio = { version = "1", features = ["sync"] }
@@ -44,10 +42,6 @@ features = ["tokio", "winit"]
 [dependencies.mpris-server]
 version = "0.8.1"
 optional = true
-
-[dependencies.smol_str]
-version = "0.2.1"
-features = ["serde"]
 
 [target.'cfg(unix)'.dependencies]
 fork = "0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,20 +103,19 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     localize::localize();
 
-    let (config_handler, config) = match cosmic_config::Config::new(App::APP_ID, CONFIG_VERSION) {
+    let config = match cosmic_config::Config::new(App::APP_ID, CONFIG_VERSION) {
         Ok(config_handler) => {
-            let config = match Config::get_entry(&config_handler) {
+            match Config::get_entry(&config_handler) {
                 Ok(ok) => ok,
                 Err((errs, config)) => {
                     log::error!("errors loading config: {:?}", errs);
                     config
                 }
-            };
-            (Some(config_handler), config)
+            }
         }
         Err(err) => {
             log::error!("failed to create config handler: {}", err);
-            (None, Config::default())
+            Config::default()
         }
     };
 
@@ -142,7 +141,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     settings = settings.size_limits(Limits::NONE.min_width(360.0).min_height(180.0));
 
     let flags = Flags {
-        config_handler,
         config,
         config_state_handler,
         config_state,
@@ -195,7 +193,6 @@ impl MenuAction for Action {
 
 #[derive(Clone)]
 pub struct Flags {
-    config_handler: Option<cosmic_config::Config>,
     config: Config,
     config_state_handler: Option<cosmic_config::Config>,
     config_state: ConfigState,
@@ -1420,7 +1417,7 @@ impl Application for App {
         Command::none()
     }
 
-    fn header_start(&self) -> Vec<Element<Self::Message>> {
+    fn header_start(&self) -> Vec<Element<'_, Self::Message>> {
         vec![menu::menu_bar(
             &self.flags.config,
             &self.flags.config_state,
@@ -1430,7 +1427,7 @@ impl Application for App {
     }
 
     /// Creates a view after each update.
-    fn view(&self) -> Element<Self::Message> {
+    fn view(&self) -> Element<'_, Self::Message> {
         let theme = theme::active();
         let cosmic_theme::Spacing {
             space_xxs,

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -10,12 +10,12 @@ use std::{collections::HashMap, path::PathBuf};
 use crate::{fl, Action, Config, ConfigState, Message};
 
 pub fn menu_bar<'a>(
-    config: &Config,
+    _config: &Config,
     config_state: &ConfigState,
     key_binds: &HashMap<KeyBind, Action>,
-    projects: &Vec<(String, PathBuf)>,
+    projects: &[(String, PathBuf)],
 ) -> Element<'a, Message> {
-    let home_dir_opt = dirs::home_dir();
+    let home_dir_opt = std::env::home_dir();
     let format_path = |path: &PathBuf| -> String {
         if let Some(home_dir) = &home_dir_opt {
             if let Ok(part) = path.strip_prefix(home_dir) {


### PR DESCRIPTION
`lazy_static` and `smol_str` weren't used. COSMIC Player used `dirs` once to find the user's home directory. Rust [fixed](https://github.com/rust-lang/libs-team/issues/372) and [undeprecated](https://doc.rust-lang.org/std/env/fn.home_dir.html) its `home_dir` function in 1.85, which released earlier this year and is the MSRV of libcosmic.
