### PR TITLE
Prevent screen turning off during playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -249,7 +249,7 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "tokio",
@@ -266,12 +266,29 @@ dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "tokio",
  "url",
  "zbus 4.4.0",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0986d5b4f0802160191ad75f8d33ada000558757db3defb70299ca95d9fcbd"
+dependencies = [
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "url",
+ "zbus 5.4.0",
 ]
 
 [[package]]
@@ -1005,7 +1022,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1082,6 +1099,7 @@ dependencies = [
 name = "cosmic-player"
 version = "0.1.0"
 dependencies = [
+ "ashpd 0.12.0",
  "clap_lex",
  "env_logger",
  "fork",
@@ -1982,6 +2000,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -4063,7 +4093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4280,14 +4310,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4297,7 +4343,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4306,7 +4362,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4405,7 +4470,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -5118,7 +5183,7 @@ checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand 2.3.0",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "rustix 0.38.43",
  "windows-sys 0.59.0",
@@ -5699,6 +5764,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -6427,6 +6501,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6600,7 +6689,7 @@ dependencies = [
  "nix 0.26.4",
  "once_cell",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",
@@ -6638,7 +6727,7 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",
@@ -6651,6 +6740,36 @@ dependencies = [
  "zbus_macros 4.4.0",
  "zbus_names 3.0.0",
  "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbddd8b6cb25d5d8ec1b23277b45299a98bfb220f1761ca11e186d5c702507f8"
+dependencies = [
+ "async-broadcast 0.7.2",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener 5.4.0",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "static_assertions",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.59.0",
+ "winnow 0.7.13",
+ "xdg-home",
+ "zbus_macros 5.4.0",
+ "zbus_names 4.2.0",
+ "zvariant 5.8.0",
 ]
 
 [[package]]
@@ -6681,6 +6800,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus_macros"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac404d48b4e9cf193c8b49589f3280ceca5ff63519e7e64f55b4cf9c47ce146"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "zbus_names 4.2.0",
+ "zvariant 5.8.0",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
 name = "zbus_names"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6700,6 +6834,18 @@ dependencies = [
  "serde",
  "static_assertions",
  "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow 0.7.13",
+ "zvariant 5.8.0",
 ]
 
 [[package]]
@@ -6810,6 +6956,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "zvariant"
+version = "5.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be61892e4f2b1772727be11630a62664a1826b62efa43a6fe7449521cb8744c"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 0.7.13",
+ "zvariant_derive 5.8.0",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
 name = "zvariant_derive"
 version = "3.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6836,6 +6997,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "zvariant_derive"
+version = "5.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da58575a1b2b20766513b1ec59d8e2e68db2745379f961f86650655e862d2006"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
 name = "zvariant_utils"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6855,4 +7029,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.96",
+ "winnow 0.7.13",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "cosmic-player"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [build-dependencies]
 vergen = { version = "8", features = ["git", "gitcl"] }
 
 [dependencies]
+ashpd = { version = "0.12", optional = true }
 gstreamer-tag = "0.23"
 image = "0.24.9"
 serde = { version = "1", features = ["serde_derive"] }
@@ -48,7 +49,7 @@ fork = "0.2"
 
 [features]
 default = ["mpris-server", "xdg-portal", "wgpu"]
-xdg-portal = ["libcosmic/xdg-portal"]
+xdg-portal = ["ashpd", "libcosmic/xdg-portal"]
 wgpu = ["iced_video_player/wgpu", "libcosmic/wgpu"]
 
 [profile.release-with-debug]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use cosmic::{
-    cosmic_config::{self, cosmic_config_derive::CosmicConfigEntry, CosmicConfigEntry},
+    cosmic_config::{self, CosmicConfigEntry, cosmic_config_derive::CosmicConfigEntry},
     theme,
 };
 use serde::{Deserialize, Serialize};

--- a/src/localize.rs
+++ b/src/localize.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 use std::sync::OnceLock;
 
 use i18n_embed::{
-    fluent::{fluent_language_loader, FluentLanguageLoader},
     DefaultLocalizer, LanguageLoader, Localizer,
+    fluent::{FluentLanguageLoader, fluent_language_loader},
 };
 use icu_collator::{Collator, CollatorOptions, Numeric};
 use icu_provider::DataLocale;

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use cosmic::{
-    theme,
-    widget::menu::{self, key_bind::KeyBind, ItemHeight, ItemWidth, MenuBar},
-    Element,
+    Element, theme,
+    widget::menu::{self, ItemHeight, ItemWidth, MenuBar, key_bind::KeyBind},
 };
 use std::{collections::HashMap, path::PathBuf};
 
-use crate::{fl, Action, Config, ConfigState, Message};
+use crate::{Action, Config, ConfigState, Message, fl};
 
 pub fn menu_bar<'a>(
     _config: &Config,

--- a/src/mpris.rs
+++ b/src/mpris.rs
@@ -3,12 +3,12 @@ use cosmic::iced::{
     subscription::{self, Subscription},
 };
 use mpris_server::{
-    zbus::{fdo, Result},
     LoopStatus, Metadata, PlaybackRate, PlaybackStatus, PlayerInterface, Property, RootInterface,
     Server, Signal, Time, TrackId, Volume,
+    zbus::{Result, fdo},
 };
 use std::{any::TypeId, future, process};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{Mutex, mpsc};
 
 use crate::{Message, MprisEvent, MprisMeta, MprisState};
 

--- a/src/thumbnail.rs
+++ b/src/thumbnail.rs
@@ -1,5 +1,5 @@
 use cosmic::iced_core::image::Data;
-use iced_video_player::{Position};
+use iced_video_player::Position;
 use image::{DynamicImage, ImageFormat, RgbaImage};
 use std::{error::Error, num::NonZero, path::Path, time::Duration};
 use url::Url;
@@ -15,7 +15,7 @@ pub fn main(
         let thumbnails = {
             let mut video = match video::new_video(input) {
                 Ok(ok) => ok,
-                Err(_err) => return Err(Into::into(format!("missing required plugin")))
+                Err(_err) => return Err(Into::into(format!("missing required plugin"))),
             };
 
             let duration = video.duration();

--- a/src/video.rs
+++ b/src/video.rs
@@ -1,12 +1,14 @@
-
 use iced_video_player::{
+    Video,
     gst::{self, prelude::*},
-    gst_app, gst_pbutils, Video,
+    gst_app, gst_pbutils,
 };
 
 use cosmic::app::{Command, message};
 
-pub fn new_video(url: &url::Url) -> Result<Video, cosmic::Command<cosmic::app::Message<super::Message>>> {
+pub fn new_video(
+    url: &url::Url,
+) -> Result<Video, cosmic::Command<cosmic::app::Message<super::Message>>> {
     //TODO: this code came from iced_video_player::Video::new and has been modified to stop the pipeline on error
     //TODO: remove unwraps and enable playback of files with only audio.
     gst::init().unwrap();
@@ -26,7 +28,10 @@ pub fn new_video(url: &url::Url) -> Result<Video, cosmic::Command<cosmic::app::M
         };
         if let Some(factory) = elem.factory() {
             if factory.name() == "souphttpsrc" {
-                elem.set_property("user-agent", "Mozilla/5.0 (X11; Linux x86_64; rv:142.0) Gecko/20100101 Firefox/142.0");
+                elem.set_property(
+                    "user-agent",
+                    "Mozilla/5.0 (X11; Linux x86_64; rv:142.0) Gecko/20100101 Firefox/142.0",
+                );
             }
         }
         None

--- a/src/xdg_portals.rs
+++ b/src/xdg_portals.rs
@@ -1,0 +1,61 @@
+// Copyright 2023 System76 <info@system76.com>
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! Integrations with XDG portals.
+
+use ashpd::{
+    desktop::inhibit::{InhibitFlags, InhibitProxy},
+    enumflags2::{BitFlags, make_bitflags},
+};
+use log::{debug, warn};
+use tokio::sync::watch::Receiver;
+
+// Actions to inhibit. Currently, COSMIC defaults to the GTK portal for Inhibit. That
+// implementation only supports inhibiting idling and trying to inhibit anything else causes the
+// D-Bus call to silently fail. We will only inhibit idling until COSMIC gets a bespoke Inhibit.
+const INHIBIT_FLAGS: BitFlags<InhibitFlags> = make_bitflags!(InhibitFlags::{Idle});
+
+/// Inhibit idle and user switching while media is played.
+///
+/// # Usage
+/// Enable the inhibitor by setting the watcher to `true`. Disable the inhibitor by sending a
+/// `false`. Sending multiple consecutive trues/falses is safe and guarded internally.
+///
+/// Portal:
+/// https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Inhibit.html
+pub async fn inhibit(mut signal: Receiver<bool>) -> ashpd::Result<()> {
+    let proxy = InhibitProxy::new().await?;
+    // Mark the watcher's value as unseen so a temporary or mutable bool isn't needed in the loop.
+    signal.mark_changed();
+
+    loop {
+        if signal.wait_for(|&status| status).await.is_err() {
+            // The watcher will likely only be closed when the app is closed.
+            debug!("Inhibit task's watcher is closed");
+            break;
+        }
+        // Copying the bool is important or else we would needlessly hold the lock below.
+        let should_inhibit = *signal.borrow_and_update();
+
+        if should_inhibit
+            && let Some(inhibit_handle) = proxy
+                .inhibit(None, INHIBIT_FLAGS, "")
+                .await
+                .inspect_err(|e| warn!("Failed to call inhibit portal endpoint: {e}"))
+                .ok()
+        {
+            // We don't have to check the bool because it's already checked to be false in the
+            // closure. We also don't have to break on error because the next iteration of the loop
+            // would break anyway.
+            let _ = signal.wait_for(|&status| !status).await;
+            if let Err(e) = inhibit_handle.close().await {
+                // This should only happen if the inhibit portal silently fails which GTK (and
+                // others!) apparently do.
+                warn!("Removing the inhibitor failed: {e}");
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Closes: #157, #31

XDG portals expose a D-Bus interface allowing apps to prevent screen idling, user switching, and other actions. That interface, org.freedesktop.portal.Inhibit, does all of the heavy lifting here.

Idling = the screen dimming or shutting off.

Idling is inhibited when a video is actively playing.
Idling is NOT inhibited when videos aren't playing - this includes
paused or stopped videos.

---

~~Draft until I have time to test.~~

I ran `cargo fmt` which accounts for the lines that reorganized imports in main.