### PR TITLE
Refine unmuting logic to trigger only on volume increase

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1194,7 +1194,9 @@ impl Application for App {
                 if let Some(video) = &mut self.video_opt {
                     if volume >= 0.0 && volume <= 1.0 {
                         video.set_volume(volume);
-                        video.set_muted(false);
+                        if volume > video.volume() {
+                            video.set_muted(false);
+                        }
                         self.update_controls(true);
                     }
                 }
@@ -1281,7 +1283,9 @@ impl Application for App {
 
                     if (volume >= 0.0 && volume <= 1.0) && !nav_bar_toggled {
                         video.set_volume(volume);
-                        video.set_muted(false);
+                        if volume > video.volume() {
+                            video.set_muted(false);
+                        }
                         self.update_controls(true);
                     }
                 }


### PR DESCRIPTION
Ensure the player remains muted during volume decreases or static adjustments; unmute only when volume is actively increased.

Implemented volume control logic to align with the modern Linux Desktop UX standard. This 'silent-by-default' paradigm—where 'Volume Down' decrements the audio level while strictly persisting the 'Mute' state—became the standard expectation starting with the GNOME 40 / libadwaita 1.0 (2021-2022) and KDE Plasma 5.25 / Frameworks 5.95 (2022) desktop cycles.
Consequently, this behavior is now native to their respective core applications, such as GNOME Videos (Totem) v40.0+ and KDE's Elisa Music Player v22.04+ (KDE Gear). To maintain parity with these applications, our volume down input acts as a passive level adjustment; only an explicit 'Volume Up' command or a direct toggle acts as an active unmute trigger.

Refines #222 to align with modern Linux Desktop UX standard.

Tandem pull request: [cosmic-settings-daemon #132](https://github.com/pop-os/cosmic-settings-daemon/pull/132)

AI was used to generate this code.

* [x]  I have disclosed use of any AI generated code in my commit messages.
  * If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  * In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
* [x]  I understand these changes in full and will be able to respond to review comments.
* [x]  My change is accurately described in the commit message.
* [x]  My contribution is tested and working as described.
* [x]  I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
