### PR TITLE
feat: implementing PlayPrevious media and UI controls

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -284,6 +284,7 @@ pub enum Message {
     Seek(f64),
     SeekRelative(f64),
     SeekRelease,
+    PlayPrevious,
     PlayNext,
     EndOfStream,
     MissingPlugin(gst::Message),
@@ -1321,6 +1322,55 @@ impl Application for App {
                 }
             }
 
+            //TODO: known limitations:
+            // 1) Same as for PlayNext #1 and #2
+            // 2) If we are at the first item in a folder and the previous folder is collapsed,
+            //    it will play the first playable file in this previous folder, not the last one
+            //    visually closer to the currently playing file.
+            Message::PlayPrevious => {
+                let curr_id = self.nav_model.active();
+                let curr_indent = self.nav_model.indent(curr_id);
+                let curr_position = match self.nav_model.position(curr_id) {
+                    Some(pos) => pos,
+                    None => {
+                        log::warn!("Failed to get position of current media: {:?}", curr_id);
+                        return self.update(Message::EndOfStream);
+                    }
+                };
+                //if we are at the first item in the navmodel (folder root), we do nothing.
+                if curr_position == 1 {
+                    return self.update(Message::None);
+                }
+                if self.nav_model.activate_position(curr_position - 1) {
+                    let curr_id = self.nav_model.active();
+                    let prev_indent = self.nav_model.indent(curr_id);
+                    match self.nav_model.data_mut::<ProjectNode>(curr_id) {
+                        //The previous one is a media file, we play it.
+                        Some(ProjectNode::File { .. }) => return self.on_nav_select(curr_id),
+
+                        //The previous one is a folder.
+                        Some(ProjectNode::Folder { .. }) => {
+                            // The previous file played was inside this folder; we need to continue
+                            // moving up.
+                            if prev_indent < curr_indent {
+                                return self.update(Message::PlayPrevious);
+                            } else {
+                                let _ = self.on_nav_select(curr_id);
+                                return self.update(Message::PlayNext);
+                            }
+                        }
+
+                        //Unknown type. We do nothing.
+                        _ => log::warn!(
+                            "unknown type: {:?}",
+                            self.nav_model.data::<ProjectNode>(curr_id)
+                        ),
+                    }
+                } else {
+                    return self.update(Message::EndOfStream);
+                }
+            }
+
             Message::PlayNext => {
                 // TODO: known limitations:
                 // 1) if the user collapses the folder entry while a song is playing,
@@ -1329,10 +1379,6 @@ impl Application for App {
                 // 2) ProjectNode::File does not restrict file types to those supported by GStreamer.
                 //    Therefore, if a non-playable file (e.g., a .jpg) is encountered in a folder, it will trigger a
                 //    "failed to open file" error and halt the stream.
-                //
-                // 3) if we play the last song of a folder and the next one is already expanded by
-                //    user (or because it was played before), the player will collapse it and jump
-                //    to the next file/folder after it.
 
                 if self.flags.config_state.player_state.repeat == RepeatState::Track {
                     // we hook Message::PlayNext to the EOS signal. iced_video_player always emits EOS regardless of
@@ -1353,12 +1399,16 @@ impl Application for App {
                 //Then we activate the next one in the nav bar and ask to load it
                 if self.nav_model.activate_position(curr_position + 1) {
                     let curr_id = self.nav_model.active();
-                    match self.nav_model.data::<ProjectNode>(curr_id) {
+                    match self.nav_model.data_mut::<ProjectNode>(curr_id) {
                         //The next one is a media file, we play it.
                         Some(ProjectNode::File { .. }) => return self.on_nav_select(curr_id),
 
                         //The next one is a folder. We expand it and recall PlayNext.
-                        Some(ProjectNode::Folder { .. }) => {
+                        Some(node @ ProjectNode::Folder { .. }) => {
+                            //in case folder was expanded previously, to not skip it
+                            if node.is_open() {
+                                let _ = self.on_nav_select(curr_id);
+                            }
                             let _ = self.on_nav_select(curr_id);
                             return self.update(Message::PlayNext);
                         }
@@ -1694,7 +1744,7 @@ impl Application for App {
             );
         }
         if self.controls {
-            let mut row = widget::row::with_capacity(8)
+            let mut row = widget::row::with_capacity(9)
                 .align_items(Alignment::Center)
                 .spacing(space_xxs)
                 .push(
@@ -1707,6 +1757,18 @@ impl Application for App {
                     )
                     .on_press(Message::PlayPause),
                 );
+            row = row.push(
+                widget::button::icon(
+                    widget::icon::from_name("media-skip-backward-symbolic").size(16),
+                )
+                .on_press(Message::PlayPrevious),
+            );
+            row = row.push(
+                widget::button::icon(
+                    widget::icon::from_name("media-skip-forward-symbolic").size(16),
+                )
+                .on_press(Message::PlayNext),
+            );
             row = row.push(widget::tooltip(
                 widget::button::icon(
                     widget::icon::from_name(match self.flags.config_state.player_state.repeat {

--- a/src/project.rs
+++ b/src/project.rs
@@ -76,6 +76,14 @@ impl ProjectNode {
             *open = !*open;
         }
     }
+
+    pub fn is_open(&mut self) -> bool {
+        if let Self::Folder { open, .. } = self {
+            *open
+        } else {
+            false
+        }
+    }
 }
 
 impl Ord for ProjectNode {


### PR DESCRIPTION
- [x ] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [ x] I understand these changes in full and will be able to respond to review comments.
- [x ] My change is accurately described in the commit message.
- [x ] My contribution is tested and working as described.
- [ x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
============================================================

### Description
This PR implement a new command in the app, `PlayPrevious` and UI controls to play previous and next media.
It also solved a known limitation for the `PlayNext` command.

### Key changes
* Added the PlayPrevious message and its associated logic.
* Included current known limitations I’ve identified (also flagged as TODOs in the code):

  * The same limitations as PlayNext 1 and 2 (non-supported file formats and user-collapsed items in the navbar).
  * If we are at the first item in a folder and the previous folder is collapsed, it will play the first playable file in that previous folder, rather than the last one visually closer to the currently playing file. (I was unable to make the nav_model behave as intended in this scenario.). It works as expected otherwise. Illustration:
  
  ![Untitled](https://github.com/user-attachments/assets/ebdcfca2-8951-402c-a810-f1c6b40132c4)

* Added UI controls for PlayPrevious and PlayNext in the control bar, next to the play/pause button.
* Solved limitation 3 of PlayNext:

  > if we play the last song of a folder and the next one is already expanded by user (or because it was played before), the player will collapse it and jump to the next file/folder after it.