### PR TITLE
Fix seek direction handling and clamp forward seeking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1350,10 +1350,9 @@ impl Application for App {
             }
             Message::SeekRelative(secs) => {
                 if let Some(video) = &mut self.video_opt {
-                    self.position = video.position().as_secs_f64();
-                    let duration =
-                        Duration::try_from_secs_f64(self.position + secs).unwrap_or_default();
-                    video.seek(duration, true).expect("seek");
+                    self.position = (video.position().as_secs_f64() + secs).clamp(0.0, self.duration);
+                    let target = Duration::try_from_secs_f64(self.position).unwrap_or_default();
+                    video.seek(target, true).expect("seek");
                 }
             }
             Message::SeekRelease => {


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
---

Summary

This PR fixes two seek-related issues in COSMIC Player:

- Fixes arrow key seeking when switching directions. Previously, after seeking forward with the right arrow key and then pressing the left arrow key, the first backward seek could move the playhead forward again instead of backward.
- Clamps forward seeking to the video duration. Previously, repeatedly clicking the +10 seconds button near the end of a video could move the displayed playback position beyond the actual media duration.

Issues:

Related to #281
Related to #282

Tested manually:
- Opened a video file longer than 40 seconds.
- Paused playback near the beginning.
- Pressed the right arrow key several times, then pressed the left arrow key.
- Confirmed that the playhead moves in the expected direction immediately after switching seek direction.
- Sought near the end of a video and clicked the +10 seconds button multiple times.
- Confirmed that the playback position no longer goes beyond the video duration.