### PR TITLE
fix: set nav_bar max height to prevent controls to overlap last item

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use cosmic::iced::event::{self, Event};
 use cosmic::iced::keyboard::key::Physical;
 use cosmic::iced::keyboard::{Event as KeyEvent, Key, Modifiers};
 use cosmic::iced::mouse::{Event as MouseEvent, ScrollDelta};
-use cosmic::iced::window::{self, set_mode};
+use cosmic::iced::window::{self, Event as WindowEvent, set_mode};
 use cosmic::iced::{
     Alignment, Background, Border, Color, ContentFit, Length, Limits, Subscription,
 };
@@ -321,6 +321,7 @@ pub enum Message {
     ShowControls,
     SystemThemeModeChange(cosmic_theme::ThemeMode),
     WindowClose,
+    WindowResized(f32),
 }
 
 /// The [`App`] stores application-specific state.
@@ -351,6 +352,7 @@ pub struct App {
     playback_speed: f64,
     #[cfg(feature = "xdg-portal")]
     inhibit: tokio::sync::watch::Sender<bool>,
+    window_height: f32,
 }
 
 impl App {
@@ -928,6 +930,7 @@ impl Application for App {
             playback_speed: 1.0,
             #[cfg(feature = "xdg-portal")]
             inhibit,
+            window_height: 0.0,
         };
 
         // Do not show nav bar by default. Will be opened by open_project if needed
@@ -957,6 +960,37 @@ impl Application for App {
             _ => app.load(),
         };
         (app, command)
+    }
+
+    fn nav_bar(&self) -> Option<Element<'_, cosmic::Action<Self::Message>>> {
+        let core = self.core();
+        if !core.nav_bar_active() {
+            return None;
+        }
+        let nav_model = self.nav_model()?;
+        let mut nav = nav_bar(nav_model, |id| {
+            cosmic::Action::Cosmic(cosmic::app::Action::NavBar(id))
+        })
+        .into_container()
+        .width(Length::Shrink)
+        .height(Length::Fill);
+
+        // if needs gap
+        if self.video_opt.is_some() && self.controls {
+            let gap = if core.window.show_headerbar {
+                100.0
+            } else {
+                60.0
+            };
+
+            nav = nav.max_height(self.window_height - gap);
+        }
+
+        if !core.is_condensed() {
+            nav = nav.max_width(280);
+        }
+
+        Some(nav.into())
     }
 
     fn nav_model(&self) -> Option<&nav_bar::Model> {
@@ -1033,6 +1067,9 @@ impl Application for App {
     /// Handle application events here.
     fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
         match message {
+            Message::WindowResized(height) => {
+                self.window_height = height;
+            }
             Message::Config(config) => {
                 if config != self.flags.config {
                     log::info!("update config");
@@ -2118,6 +2155,9 @@ impl Application for App {
                 }) => Some(Message::Key(modifiers, physical_key, key)),
                 Event::Mouse(MouseEvent::CursorMoved { .. }) => Some(Message::ShowControls),
                 Event::Mouse(MouseEvent::WheelScrolled { delta }) => Some(Message::Scrolled(delta)),
+                Event::Window(WindowEvent::Resized(size)) => {
+                    Some(Message::WindowResized(size.height))
+                }
                 _ => None,
             }),
             cosmic_config::config_subscription(


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
## Summary

- Added nav_bar max height

This pull request fixes the controls overlapping the last item by dynamically applying a gap

<img width="1027" height="700" alt="image" src="https://github.com/user-attachments/assets/789f0a10-2982-4416-bcdf-46d96185560a" />

<img width="1027" height="700" alt="image" src="https://github.com/user-attachments/assets/2ff82a06-2f68-422c-9db3-cb0db96efb53" />

<img width="1027" height="700" alt="image" src="https://github.com/user-attachments/assets/e0174aab-5c2e-4167-9ef0-6589d32f1c4f" />

<img width="1027" height="700" alt="image" src="https://github.com/user-attachments/assets/abd3adfb-1693-4178-a7c1-f09d1a2fdef1" />

<img width="1027" height="700" alt="image" src="https://github.com/user-attachments/assets/687e70f6-a457-4c93-9d5a-367f590e4554" />

Closes #213 
