### PR TITLE
i18n(is): complete Icelandic translation to 100% parity

### DIFF
--- a/i18n/is/cosmic_player.ftl
+++ b/i18n/is/cosmic_player.ftl
@@ -21,3 +21,19 @@ close-file = Loka skrá
 open-media-folder = Opna miðlamöppu...
 open-recent-media-folder = Opna nýlega miðlamöppu
 close-media-folder = Loka miðlamöppu
+
+clear-recent = Hreinsa nýlegan lista
+repeat-disabled = Endurtekning óvirk
+repeat-track = Endurtaka spor
+playback = Afspilun
+next-frame = Næsti rammi
+previous-frame = Fyrri rammi
+ab-repeat = A-B endurtekning
+ab-repeat-set-a = A-B endurtekning (A)
+ab-repeat-set-b = A-B endurtekning (B)
+ab-repeat-clear = Hreinsa A-B endurtekningu
+
+# XDG Metadata
+xdg-name = COSMIC Miðlaspilari
+xdg-comment = Miðlaspilari fyrir COSMIC skjáborðið
+xdg-keywords = Audio;Film;Movie;Music;Sound;Video;Hljóð;Kvikmynd;Tónlist;Myndband;Vídeó;


### PR DESCRIPTION
Completes the Icelandic (`is`) localization to 100% key parity with `en`.

Terminology grounded in Íðorðabankinn (the TOLVA computing dictionary, Árnastofnun) and made consistent with COSMIC's existing Icelandic translations. Fluent placeables, selector keys, attributes, and proper nouns are preserved; only human-readable text was translated. Validated with `fluent.syntax` (no Junk) and full en/is key-parity checks.