### PR TITLE
Preserve playback state during scrubbing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1327,9 +1327,11 @@ impl Application for App {
                 self.dropdown_opt = None;
 
                 if let Some(video) = &mut self.video_opt {
+                    if !self.dragging {
+                        self.paused_on_scrub = video.paused();
+                    }
                     self.dragging = true;
                     self.position = secs;
-                    self.paused_on_scrub = video.paused();
                     video.set_paused(true);
                     let duration = Duration::try_from_secs_f64(self.position).unwrap_or_default();
                     video.seek(duration, true).expect("seek");


### PR DESCRIPTION
## Summary

- capture the playback state only when a scrub gesture begins
- preserve the original playing or paused state across repeated slider updates
- leave click seeking and relative seeking unchanged

Fixes #305.

Detailed reproduction and source diagnosis: #325.

## Testing

- `cargo +1.93.0 check --locked`
- `cargo +1.93.0 test --locked` (the project currently defines no unit tests)
- `cargo +1.93.0 build --locked`
- `git diff --check`
- manually verified that scrubbing playing media resumes playback
- manually verified that scrubbing paused media remains paused
- manually verified click seeking and relative seeking
- manually exercised MP4, WebM, FLAC, MP3, and OGG media in normal and condensed layouts

`cargo +1.93.0 fmt --check` still reports the existing import-order difference in the unmodified `build.rs`. The modified `src/main.rs` is not reported by the formatter.

## AI Assistance

Codex assisted with tracing the seek-state flow, preparing the narrow patch, and running validation. I reviewed and understand the change and can respond to review feedback. The commit message also discloses this assistance.

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
